### PR TITLE
Update imports and ZoneGenerator methods for CR0.5.19

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -57,10 +57,10 @@ joml_version = 1.10.7
 lwjgl_version = 3.3.3
 
 # Cosmic Reach
-cosmic_reach_version = 0.5.13-alpha
+cosmic_reach_version = 0.5.19-alpha
 
 # Puzzle Loader
 puzzle_core_version = 1.4.0-alpha
 
 # Puzzle Gradle
-puzzle_jigsaw_suite_version = 1.3.1-beta
+puzzle_jigsaw_suite_version = 1.3.2-beta

--- a/src/client/java/dev/puzzleshq/puzzleloader/cosmic/core/mixins/client/autojoin/MainMenuInit.java
+++ b/src/client/java/dev/puzzleshq/puzzleloader/cosmic/core/mixins/client/autojoin/MainMenuInit.java
@@ -3,7 +3,7 @@ package dev.puzzleshq.puzzleloader.cosmic.core.mixins.client.autojoin;
 import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.utils.Json;
 import dev.puzzleshq.puzzleloader.cosmic.game.CommonPuzzle;
-import finalforeach.cosmicreach.Threads;
+import finalforeach.cosmicreach.util.Threads;
 import finalforeach.cosmicreach.gamestates.GameState;
 import finalforeach.cosmicreach.gamestates.LoadingGame;
 import finalforeach.cosmicreach.gamestates.MainMenu;

--- a/src/client/java/dev/puzzleshq/puzzleloader/cosmic/game/blockloader/loading/ClientSidedModelLoader.java
+++ b/src/client/java/dev/puzzleshq/puzzleloader/cosmic/game/blockloader/loading/ClientSidedModelLoader.java
@@ -4,7 +4,7 @@ import dev.puzzleshq.puzzleloader.cosmic.game.blockloader.client.BlockModelBuild
 import dev.puzzleshq.puzzleloader.cosmic.game.blockloader.generation.model.BlockModelGenerator;
 import dev.puzzleshq.puzzleloader.cosmic.game.blockloader.generation.state.State;
 import dev.puzzleshq.puzzleloader.loader.util.ReflectionUtil;
-import finalforeach.cosmicreach.GameAssetLoader;
+import finalforeach.cosmicreach.util.assets.GameAssetLoader;
 import finalforeach.cosmicreach.rendering.blockmodels.BlockModel;
 import finalforeach.cosmicreach.rendering.blockmodels.BlockModelJson;
 import finalforeach.cosmicreach.util.Identifier;

--- a/src/common/java/dev/puzzleshq/puzzleloader/cosmic/core/mixins/common/MixinGameAssetLoaderUtils.java
+++ b/src/common/java/dev/puzzleshq/puzzleloader/cosmic/core/mixins/common/MixinGameAssetLoaderUtils.java
@@ -2,7 +2,7 @@ package dev.puzzleshq.puzzleloader.cosmic.core.mixins.common;
 
 import dev.puzzleshq.mod.api.IModContainer;
 import dev.puzzleshq.puzzleloader.loader.util.ModFinder;
-import finalforeach.cosmicreach.util.GameAssetLoaderUtils;
+import finalforeach.cosmicreach.util.assets.GameAssetLoaderUtils;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;

--- a/src/common/java/dev/puzzleshq/puzzleloader/cosmic/core/mixins/common/MixinZoneGenerator.java
+++ b/src/common/java/dev/puzzleshq/puzzleloader/cosmic/core/mixins/common/MixinZoneGenerator.java
@@ -16,16 +16,16 @@ import java.util.function.Supplier;
 @Mixin(ZoneGenerator.class)
 public abstract class MixinZoneGenerator {
     @Shadow
-    public static void registerZoneGenerator(ZoneGenerator zoneGenerator) {}
+    public static void registerZoneGenerator(String saveKey, Supplier<ZoneGenerator> zoneGeneratorSupplier) {}
 
-    @Inject(method = "registerZoneGenerators", at = @At(value = "INVOKE", target = "Lfinalforeach/cosmicreach/worldgen/ZoneGenerator;registerZoneGenerator(Lfinalforeach/cosmicreach/worldgen/ZoneGenerator;)V", ordinal = 0))
+    @Inject(method = "registerZoneGenerators", at = @At(value = "INVOKE", target = "Lfinalforeach/cosmicreach/worldgen/ZoneGenerator;registerZoneGenerator(Ljava/lang/String;Ljava/util/function/Supplier;)V", ordinal = 0))
     private static void registerZoneGenerators(CallbackInfo ci) {
         List<Supplier<ZoneGenerator>> zoneGenerators = new ArrayList<>();
 
         GameRegistries.COSMIC_EVENT_BUS.post(new EventRegisterZoneGenerator(zoneGenerators));
 
         for (Supplier<ZoneGenerator> generatorSupplier : zoneGenerators) {
-            registerZoneGenerator(generatorSupplier.get());
+            registerZoneGenerator(generatorSupplier.get().getSaveKey(), generatorSupplier);
         }
 
     }

--- a/src/common/java/dev/puzzleshq/puzzleloader/cosmic/game/blockloader/generation/event/BlockEventGenerator.java
+++ b/src/common/java/dev/puzzleshq/puzzleloader/cosmic/game/blockloader/generation/event/BlockEventGenerator.java
@@ -3,7 +3,7 @@ package dev.puzzleshq.puzzleloader.cosmic.game.blockloader.generation.event;
 import com.badlogic.gdx.files.FileHandle;
 import dev.puzzleshq.puzzleloader.cosmic.game.blockloader.block.InjectedBlockAction;
 import dev.puzzleshq.puzzleloader.cosmic.game.util.HJsonSerializable;
-import finalforeach.cosmicreach.GameAssetLoader;
+import finalforeach.cosmicreach.util.assets.GameAssetLoader;
 import finalforeach.cosmicreach.gameevents.blockevents.BlockEventArgs;
 import finalforeach.cosmicreach.util.Identifier;
 import org.hjson.JsonObject;

--- a/src/server/java/dev/puzzleshq/puzzleloader/cosmic/game/blockloader/loading/ServerSidedModelLoader.java
+++ b/src/server/java/dev/puzzleshq/puzzleloader/cosmic/game/blockloader/loading/ServerSidedModelLoader.java
@@ -3,7 +3,7 @@ package dev.puzzleshq.puzzleloader.cosmic.game.blockloader.loading;
 import dev.puzzleshq.puzzleloader.cosmic.game.blockloader.generation.model.BlockModelGenerator;
 import dev.puzzleshq.puzzleloader.cosmic.game.blockloader.generation.state.State;
 import dev.puzzleshq.puzzleloader.loader.util.ReflectionUtil;
-import finalforeach.cosmicreach.GameAssetLoader;
+import finalforeach.cosmicreach.util.assets.GameAssetLoader;
 import finalforeach.cosmicreach.rendering.blockmodels.BlockModel;
 import finalforeach.cosmicreach.rendering.blockmodels.DummyBlockModel;
 import finalforeach.cosmicreach.util.Identifier;


### PR DESCRIPTION
Update imports for classes that were moved into a `util` subdirectory. Update `ZoneGenerator` mixins for methods that have changed headers.